### PR TITLE
Correct Loss in the tabulate

### DIFF
--- a/libmultilabel/nn/metrics.py
+++ b/libmultilabel/nn/metrics.py
@@ -32,7 +32,7 @@ class Loss(Metric):
         self.num_sample += len(preds)
 
     def compute(self):
-        return self.loss / self.num_sample
+        return self.loss / self.num_sample * 0.01
 
 
 class NDCG(Metric):


### PR DESCRIPTION
## What does this PR do?

- Correct Loss in the tabulate ：the value of Loss was multiplied by 100 like other metrics and now it returns normal value.

## Test CLI & API (`bash tests/autotest.sh`)
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_examples.sh`)
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)